### PR TITLE
Update README [Fix #1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ It will
 * delete `req.session`
 * redirect to `req.query.returnTo` if exists, if not `res.send(bye)`
 
+It will not
+* work with passport extensions which use OAuth such as passport-github
+
 ## Install
 
 	npm install express-passport-logout


### PR DESCRIPTION
Updated README to specify that this library will not work with passport extensions which use OAuth. This is an important distinction to make because it is not obvious. Not noting this explicitly could cause developers to waste their time.
